### PR TITLE
Stabilize external HTTP tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 
 require (
 	github.com/beevik/ntp v1.5.0
-	github.com/mccutchen/go-httpbin v1.1.1
 	github.com/ncruces/go-dns v1.3.3
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pires/go-proxyproto v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mccutchen/go-httpbin v1.1.1 h1:aEws49HEJEyXHLDnshQVswfUlCVoS8g6h9YaDyaW7RE=
-github.com/mccutchen/go-httpbin v1.1.1/go.mod h1:fhpOYavp5g2K74XDl/ao2y4KvhqVtKlkg1e+0UaQv7I=
+github.com/mccutchen/go-httpbin/v2 v2.23.1 h1:F/05blJUzgTVTBd5bUW0cstUXnqnv5KIetb6uBciyG4=
 github.com/mccutchen/go-httpbin/v2 v2.23.1/go.mod h1:8hkN5rHf0QvJYEovZ8u/Dudtqyj6Z5gxQaW7scQfT0Y=
 github.com/miekg/dns v1.1.51 h1:0+Xg7vObnhrz/4ZCZcZh7zPXlmU0aveS2HDBd0m0qSo=
 github.com/miekg/dns v1.1.51/go.mod h1:2Z9d3CP1LQWihRZUf29mQ19yDThaI4DAYzte2CaQW5c=

--- a/mtglib/proxy_test.go
+++ b/mtglib/proxy_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/yl2chen/cidranger"
 )
 
+const externalHTTPBinHost = "httpbin.io"
+
 type ProxyTestSuite struct {
 	suite.Suite
 
@@ -61,7 +63,7 @@ func (suite *ProxyTestSuite) SetupSuite() {
 	go allowlist.Run(time.Second)
 
 	suite.opts = &mtglib.ProxyOpts{
-		Secret:          mtglib.GenerateSecret("httpbin.org"),
+		Secret:          mtglib.GenerateSecret(externalHTTPBinHost),
 		Network:         ntw,
 		AntiReplayCache: antireplay.NewNoop(),
 		IPBlocklist:     ipblocklist.NewNoop(),
@@ -159,7 +161,7 @@ func (suite *ProxyTestSuite) TestCannotInitIncorrectPreferIP() {
 }
 
 func (suite *ProxyTestSuite) TestDomainFrontingAddress() {
-	suite.Equal("httpbin.org:443", suite.p.DomainFrontingAddress())
+	suite.Equal(externalHTTPBinHost+":443", suite.p.DomainFrontingAddress())
 }
 
 func (suite *ProxyTestSuite) TestHTTPSRequest() {
@@ -174,24 +176,34 @@ func (suite *ProxyTestSuite) TestHTTPSRequest() {
 
 	addr := fmt.Sprintf("https://%s/headers", suite.ProxyAddress())
 
-	resp, err := client.Get(addr) //nolint: noctx
-	suite.Require().NoError(err)
+	var resp *http.Response
+	suite.Require().Eventually(func() bool {
+		candidate, err := client.Get(addr) //nolint: noctx
+		if err != nil {
+			return false
+		}
+		if candidate.StatusCode == http.StatusOK {
+			resp = candidate
+
+			return true
+		}
+
+		candidate.Body.Close() //nolint: errcheck
+
+		return false
+	}, 30*time.Second, time.Second)
 
 	defer resp.Body.Close() //nolint: errcheck
-
-	suite.Equal(http.StatusOK, resp.StatusCode)
 
 	data, err := io.ReadAll(resp.Body)
 	suite.NoError(err)
 
 	jsonStruct := struct {
-		Headers struct {
-			TraceID string `json:"X-Amzn-Trace-Id"` //nolint: tagliatelle
-		} `json:"headers"`
+		Headers map[string][]string `json:"headers"`
 	}{}
 
 	suite.NoError(json.Unmarshal(data, &jsonStruct))
-	suite.NotEmpty(jsonStruct.Headers.TraceID)
+	suite.NotEmpty(jsonStruct.Headers)
 }
 
 func TestProxy(t *testing.T) {

--- a/mtglib/proxy_test.go
+++ b/mtglib/proxy_test.go
@@ -186,7 +186,7 @@ func (suite *ProxyTestSuite) TestHTTPSRequest() {
 
 			return false
 		}
-		if candidate.StatusCode < http.StatusInternalServerError {
+		if candidate.StatusCode == http.StatusOK {
 			resp = candidate
 
 			return true

--- a/mtglib/proxy_test.go
+++ b/mtglib/proxy_test.go
@@ -180,9 +180,13 @@ func (suite *ProxyTestSuite) TestHTTPSRequest() {
 	suite.Require().Eventually(func() bool {
 		candidate, err := client.Get(addr) //nolint: noctx
 		if err != nil {
+			if candidate != nil {
+				candidate.Body.Close() //nolint: errcheck
+			}
+
 			return false
 		}
-		if candidate.StatusCode == http.StatusOK {
+		if candidate.StatusCode < http.StatusInternalServerError {
 			resp = candidate
 
 			return true
@@ -194,12 +198,13 @@ func (suite *ProxyTestSuite) TestHTTPSRequest() {
 	}, 30*time.Second, time.Second)
 
 	defer resp.Body.Close() //nolint: errcheck
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
 
 	data, err := io.ReadAll(resp.Body)
 	suite.NoError(err)
 
 	jsonStruct := struct {
-		Headers map[string][]string `json:"headers"`
+		Headers map[string]json.RawMessage `json:"headers"`
 	}{}
 
 	suite.NoError(json.Unmarshal(data, &jsonStruct))

--- a/network/init_test.go
+++ b/network/init_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/IceCodeNew/mtg/essentials"
 	"github.com/IceCodeNew/mtg/network"
 	socks5 "github.com/armon/go-socks5"
-	"github.com/mccutchen/go-httpbin/httpbin"
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -36,7 +36,7 @@ type HTTPServerTestSuite struct {
 }
 
 func (suite *HTTPServerTestSuite) SetupSuite() {
-	suite.httpServer = httptest.NewServer(httpbin.NewHTTPBin().Handler())
+	suite.httpServer = httptest.NewServer(httpbin.New().Handler())
 }
 
 func (suite *HTTPServerTestSuite) TearDownSuite() {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -9,10 +9,52 @@ import (
 	"time"
 
 	"github.com/IceCodeNew/mtg/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 const externalHTTPBinHost = "httpbin.io"
+
+type headerValues []string
+
+func (values *headerValues) UnmarshalJSON(data []byte) error {
+	var multiple []string
+	if err := json.Unmarshal(data, &multiple); err == nil {
+		*values = multiple
+
+		return nil
+	}
+
+	var single string
+	if err := json.Unmarshal(data, &single); err != nil {
+		return err
+	}
+
+	*values = []string{single}
+
+	return nil
+}
+
+func TestHeaderValues(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		json     string
+		expected headerValues
+	}{
+		"single": {json: `"itsme"`, expected: headerValues{"itsme"}},
+		"array":  {json: `["itsme"]`, expected: headerValues{"itsme"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var actual headerValues
+			require.NoError(t, json.Unmarshal([]byte(test.json), &actual))
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
 
 type NetworkTestSuite struct {
 	suite.Suite
@@ -69,9 +111,13 @@ func (suite *NetworkTestSuite) TestRealHTTPRequest() {
 	suite.Require().Eventually(func() bool {
 		candidate, err := client.Get(externalURL) //nolint: noctx
 		if err != nil {
+			if candidate != nil {
+				candidate.Body.Close() //nolint: errcheck
+			}
+
 			return false
 		}
-		if candidate.StatusCode == http.StatusOK {
+		if candidate.StatusCode < http.StatusInternalServerError {
 			resp = candidate
 
 			return true
@@ -83,17 +129,18 @@ func (suite *NetworkTestSuite) TestRealHTTPRequest() {
 	}, 30*time.Second, time.Second)
 
 	defer resp.Body.Close() //nolint: errcheck
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
 
 	data, err := io.ReadAll(resp.Body)
 	suite.NoError(err)
 	jsonStruct := struct {
 		Headers struct {
-			UserAgent []string `json:"User-Agent"` //nolint: tagliatelle
+			UserAgent headerValues `json:"User-Agent"` //nolint: tagliatelle
 		} `json:"headers"`
 	}{}
 
 	suite.NoError(json.Unmarshal(data, &jsonStruct))
-	suite.Equal([]string{"itsme"}, jsonStruct.Headers.UserAgent)
+	suite.Equal(headerValues{"itsme"}, jsonStruct.Headers.UserAgent)
 }
 
 func (suite *NetworkTestSuite) TestIncorrectTimeout() {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -39,16 +39,17 @@ func (values *headerValues) UnmarshalJSON(data []byte) error {
 func TestHeaderValues(t *testing.T) {
 	t.Parallel()
 
-	for name, test := range map[string]struct {
+	tests := []struct {
+		name     string
 		json     string
 		expected headerValues
 	}{
-		"single": {json: `"itsme"`, expected: headerValues{"itsme"}},
-		"array":  {json: `["itsme"]`, expected: headerValues{"itsme"}},
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+		{name: "single", json: `"itsme"`, expected: headerValues{"itsme"}},
+		{name: "array", json: `["itsme"]`, expected: headerValues{"itsme"}},
+	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var actual headerValues
 			require.NoError(t, json.Unmarshal([]byte(test.json), &actual))
 			assert.Equal(t, test.expected, actual)
@@ -117,7 +118,7 @@ func (suite *NetworkTestSuite) TestRealHTTPRequest() {
 
 			return false
 		}
-		if candidate.StatusCode < http.StatusInternalServerError {
+		if candidate.StatusCode == http.StatusOK {
 			resp = candidate
 
 			return true

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/IceCodeNew/mtg/network"
 	"github.com/stretchr/testify/suite"
 )
+
+const externalHTTPBinHost = "httpbin.io"
 
 type NetworkTestSuite struct {
 	suite.Suite
@@ -56,23 +59,41 @@ func (suite *NetworkTestSuite) TestRealHTTPRequest() {
 
 	client := ntw.MakeHTTPClient(nil)
 
-	resp, err := client.Get("https://httpbin.org/headers") //nolint: noctx
-	suite.NoError(err)
+	externalURL := (&url.URL{
+		Scheme: "https",
+		Host:   externalHTTPBinHost,
+		Path:   "/headers",
+	}).String()
+
+	var resp *http.Response
+	suite.Require().Eventually(func() bool {
+		candidate, err := client.Get(externalURL) //nolint: noctx
+		if err != nil {
+			return false
+		}
+		if candidate.StatusCode == http.StatusOK {
+			resp = candidate
+
+			return true
+		}
+
+		candidate.Body.Close() //nolint: errcheck
+
+		return false
+	}, 30*time.Second, time.Second)
 
 	defer resp.Body.Close() //nolint: errcheck
 
 	data, err := io.ReadAll(resp.Body)
 	suite.NoError(err)
-	suite.Equal(http.StatusOK, resp.StatusCode)
-
 	jsonStruct := struct {
 		Headers struct {
-			UserAgent string `json:"User-Agent"` //nolint: tagliatelle
+			UserAgent []string `json:"User-Agent"` //nolint: tagliatelle
 		} `json:"headers"`
 	}{}
 
 	suite.NoError(json.Unmarshal(data, &jsonStruct))
-	suite.Equal("itsme", jsonStruct.Headers.UserAgent)
+	suite.Equal([]string{"itsme"}, jsonStruct.Headers.UserAgent)
 }
 
 func (suite *NetworkTestSuite) TestIncorrectTimeout() {


### PR DESCRIPTION
## Summary

- migrate the local HTTP test server to go-httpbin v2 from #81 and remove the stale v1 dependency
- replace the unreliable `httpbin.org` test target with `httpbin.io`, which supports the proxy test's intentional no-SNI TLS handshake
- retry transient external HTTP failures for up to 30 seconds while keeping both real-network tests unconditional

## Root cause

`httpbin.org` intermittently returns 503 responses or times out. The same failures are visible in upstream `9seconds/mtg` CI run 27693300969. Because the coverage task runs tests twice, a transient failure in either pass fails the entire job.

The proxy test intentionally connects without exposing the target through SNI, so the replacement endpoint was verified to accept a no-SNI TLS connection.

## Impact

CI remains an unconditional end-to-end real-network check, including the no-SNI domain-fronting behavior, but no longer depends on the unstable `httpbin.org` service.

## Validation

- `mise exec -- go test -race -count=2 -v ./network ./mtglib`
- `mise tasks run covtest` — passed, 69.1% total statement coverage
- `mise tasks run lint` — 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP integration test reliability by retrying transient external request failures.
  * Added coverage for HTTP headers returned as either single values or lists.
  * Updated proxy and network validation to use flexible, environment-independent host configuration.
  * Updated test HTTP server handling to align with current behavior and improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->