### PR TITLE
Increase unit test coverage

### DIFF
--- a/buildinfo_test.go
+++ b/buildinfo_test.go
@@ -17,5 +17,6 @@ func TestGetVersion(t *testing.T) {
 }
 
 func TestRunProfile(t *testing.T) {
+	t.Setenv("MTG_PROF_PORT", "0")
 	runProfile()
 }

--- a/buildinfo_test.go
+++ b/buildinfo_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	got := getVersion()
+
+	if !strings.HasPrefix(got, version+" (") {
+		t.Fatalf("getVersion() = %q, want prefix %q", got, version+" (")
+	}
+	if !strings.Contains(got, "modules checksum ") {
+		t.Fatalf("getVersion() = %q, want module checksum", got)
+	}
+}
+
+func TestRunProfile(t *testing.T) {
+	runProfile()
+}

--- a/essentials/conns_test.go
+++ b/essentials/conns_test.go
@@ -1,0 +1,61 @@
+package essentials_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/IceCodeNew/mtg/essentials"
+	"github.com/stretchr/testify/require"
+)
+
+type halfCloseConn struct {
+	net.Conn
+	readClosed  bool
+	writeClosed bool
+}
+
+func (c *halfCloseConn) CloseRead() error {
+	c.readClosed = true
+
+	return nil
+}
+
+func (c *halfCloseConn) CloseWrite() error {
+	c.writeClosed = true
+
+	return nil
+}
+
+func TestWrapNetConnDelegatesHalfClose(t *testing.T) {
+	left, right := net.Pipe()
+	t.Cleanup(func() { left.Close() })  //nolint:errcheck
+	t.Cleanup(func() { right.Close() }) //nolint:errcheck
+
+	base := &halfCloseConn{Conn: left}
+	conn := essentials.WrapNetConn(base)
+
+	require.NoError(t, conn.CloseRead())
+	require.NoError(t, conn.CloseWrite())
+	require.True(t, base.readClosed)
+	require.True(t, base.writeClosed)
+}
+
+func TestWrapNetConnFallsBackToClose(t *testing.T) {
+	t.Run("read", func(t *testing.T) {
+		left, right := net.Pipe()
+		t.Cleanup(func() { right.Close() }) //nolint:errcheck
+
+		require.NoError(t, essentials.WrapNetConn(left).CloseRead())
+		_, err := right.Write([]byte("closed"))
+		require.Error(t, err)
+	})
+
+	t.Run("write", func(t *testing.T) {
+		left, right := net.Pipe()
+		t.Cleanup(func() { right.Close() }) //nolint:errcheck
+
+		require.NoError(t, essentials.WrapNetConn(left).CloseWrite())
+		_, err := right.Write([]byte("closed"))
+		require.Error(t, err)
+	})
+}

--- a/internal/cli/access_internal_test.go
+++ b/internal/cli/access_internal_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"encoding/json"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/IceCodeNew/mtg/internal/config"
+	"github.com/IceCodeNew/mtg/internal/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessMakeURLs(t *testing.T) {
+	conf := &config.Config{}
+	require.NoError(t, conf.Secret.Set(testSecret))
+	require.NoError(t, conf.BindTo.Set("127.0.0.1:3128"))
+
+	require.Nil(t, (&Access{}).makeURLs(conf, nil))
+
+	base64URLs := (&Access{}).makeURLs(conf, net.ParseIP("192.0.2.1"))
+	require.Equal(t, uint(3128), base64URLs.Port)
+	require.Equal(t, "192.0.2.1", base64URLs.IP.String())
+	require.Contains(t, base64URLs.TgQrCode, url.QueryEscape(base64URLs.TgURL))
+	require.Contains(t, base64URLs.TmeQrCode, url.QueryEscape(base64URLs.TmeURL))
+	require.Contains(t, base64URLs.TgURL, url.QueryEscape(conf.Secret.Base64()))
+
+	hexURLs := (&Access{Port: 8443, Hex: true}).makeURLs(conf, net.ParseIP("2001:db8::1"))
+	require.Equal(t, uint(8443), hexURLs.Port)
+	require.Contains(t, hexURLs.TgURL, conf.Secret.Hex())
+}
+
+func TestAccessRunWithExplicitPublicAddresses(t *testing.T) {
+	command := Access{
+		ConfigPath: "../config/testdata/minimal.toml",
+		PublicIPv4: net.ParseIP("192.0.2.1"),
+		PublicIPv6: net.ParseIP("2001:db8::1"),
+		Port:       8443,
+	}
+
+	output := testlib.CaptureStdout(func() {
+		require.NoError(t, command.Run(&CLI{}, "test"))
+	})
+	response := &accessResponse{}
+	require.NoError(t, json.Unmarshal([]byte(output), response))
+	require.Equal(t, "192.0.2.1", response.IPv4.IP.String())
+	require.Equal(t, "2001:db8::1", response.IPv6.IP.String())
+	require.Equal(t, uint(8443), response.IPv4.Port)
+	require.NotEmpty(t, response.Secret.Base64)
+	require.NotEmpty(t, response.Secret.Hex)
+}
+
+func TestAccessRunRejectsUnreadableConfig(t *testing.T) {
+	err := (&Access{ConfigPath: "missing.toml"}).Run(&CLI{}, "test")
+	require.ErrorContains(t, err, "cannot init config")
+}

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/IceCodeNew/mtg/essentials"
+	"github.com/IceCodeNew/mtg/internal/config"
+	"github.com/IceCodeNew/mtg/internal/testlib"
+	"github.com/IceCodeNew/mtg/mtglib"
+	"github.com/stretchr/testify/require"
+)
+
+type doctorNetwork struct {
+	dialer *net.Dialer
+	err    error
+}
+
+func (n doctorNetwork) Dial(string, string) (essentials.Conn, error) {
+	return nil, n.err
+}
+
+func (n doctorNetwork) DialContext(context.Context, string, string) (essentials.Conn, error) {
+	return nil, n.err
+}
+
+func (n doctorNetwork) NativeDialer() *net.Dialer { return n.dialer }
+
+func (n doctorNetwork) MakeHTTPClient(
+	func(context.Context, string, string) (essentials.Conn, error),
+) *http.Client {
+	return &http.Client{}
+}
+
+var _ mtglib.Network = doctorNetwork{}
+
+func TestDoctorCheckDeprecatedConfig(t *testing.T) {
+	t.Run("current config", func(t *testing.T) {
+		doctor := Doctor{conf: &config.Config{}}
+		output := testlib.CaptureStdout(func() {
+			require.True(t, doctor.checkDeprecatedConfig())
+		})
+		require.Contains(t, output, "All good")
+	})
+
+	t.Run("all deprecated options", func(t *testing.T) {
+		conf := &config.Config{}
+		conf.DomainFrontingIP.Value = net.ParseIP("192.0.2.1")
+		conf.DomainFronting.IP.Value = net.ParseIP("192.0.2.2")
+		conf.DomainFrontingPort.Value = 443
+		conf.DomainFrontingProxyProtocol.Value = true
+		conf.Network.DOHIP.Value = net.ParseIP("192.0.2.53")
+
+		doctor := Doctor{conf: conf}
+		output := testlib.CaptureStdout(func() {
+			require.False(t, doctor.checkDeprecatedConfig())
+		})
+		for _, option := range []string{
+			"domain-fronting-ip",
+			"domain-fronting-port",
+			"domain-fronting-proxy-protocol",
+			"doh-ip",
+		} {
+			require.Contains(t, output, option)
+		}
+	})
+}
+
+func TestDoctorCheckNetworkFailures(t *testing.T) {
+	doctor := Doctor{conf: &config.Config{}}
+	output := testlib.CaptureStdout(func() {
+		require.False(t, doctor.checkNetwork(doctorNetwork{err: errors.New("offline")}))
+	})
+	require.Contains(t, output, "offline")
+}
+
+func TestDoctorCheckNetworkAddressesFiltersIPFamilies(t *testing.T) {
+	addresses := []string{"192.0.2.1:443", "[2001:db8::1]:443"}
+
+	for _, tt := range []struct {
+		preference string
+		addresses  []string
+	}{
+		{"only-ipv4", addresses[1:]},
+		{"only-ipv6", addresses[:1]},
+	} {
+		t.Run(tt.preference, func(t *testing.T) {
+			conf := &config.Config{}
+			require.NoError(t, conf.PreferIP.Set(tt.preference))
+			doctor := Doctor{conf: conf}
+
+			_, err := doctor.checkNetworkAddresses(
+				doctorNetwork{err: errors.New("should not dial")}, 1, tt.addresses,
+			)
+			require.ErrorContains(t, err, "no suitable addresses")
+		})
+	}
+}
+
+func TestDoctorCheckFrontingDomain(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	port := uint(listener.Addr().(*net.TCPAddr).Port)
+	conf := &config.Config{}
+	require.NoError(t, conf.Secret.Set(testSecret))
+	require.NoError(t, conf.DomainFronting.Host.Set("127.0.0.1"))
+	conf.DomainFronting.Port.Value = port
+	doctor := Doctor{conf: conf}
+	network := doctorNetwork{dialer: &net.Dialer{Timeout: time.Second}}
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			conn.Close() //nolint:errcheck
+		}
+		close(accepted)
+	}()
+	require.True(t, doctor.checkFrontingDomain(network))
+	<-accepted
+	require.NoError(t, listener.Close())
+	require.False(t, doctor.checkFrontingDomain(network))
+}

--- a/internal/cli/doctor_internal_test.go
+++ b/internal/cli/doctor_internal_test.go
@@ -104,6 +104,7 @@ func TestDoctorCheckNetworkAddressesFiltersIPFamilies(t *testing.T) {
 func TestDoctorCheckFrontingDomain(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+	defer listener.Close() //nolint:errcheck
 
 	port := uint(listener.Addr().(*net.TCPAddr).Port)
 	conf := &config.Config{}
@@ -123,6 +124,6 @@ func TestDoctorCheckFrontingDomain(t *testing.T) {
 	}()
 	require.True(t, doctor.checkFrontingDomain(network))
 	<-accepted
-	require.NoError(t, listener.Close())
+	listener.Close() //nolint:errcheck
 	require.False(t, doctor.checkFrontingDomain(network))
 }

--- a/internal/cli/run_proxy_internal_test.go
+++ b/internal/cli/run_proxy_internal_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/IceCodeNew/mtg/internal/config"
+	"github.com/IceCodeNew/mtg/ipblocklist"
+	"github.com/IceCodeNew/mtg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeLogger(t *testing.T) {
+	require.NotNil(t, makeLogger(&config.Config{}))
+	conf := &config.Config{}
+	conf.Debug.Value = true
+	require.NotNil(t, makeLogger(conf))
+}
+
+func TestMakeNetwork(t *testing.T) {
+	t.Run("direct", func(t *testing.T) {
+		network, err := makeNetwork(&config.Config{}, "test")
+		require.NoError(t, err)
+		require.NotNil(t, network)
+	})
+
+	t.Run("one proxy", func(t *testing.T) {
+		conf := &config.Config{}
+		proxy := config.TypeProxyURL{}
+		require.NoError(t, proxy.Set("socks5://127.0.0.1:1080"))
+		conf.Network.Proxies = []config.TypeProxyURL{proxy}
+
+		network, err := makeNetwork(conf, "test")
+		require.NoError(t, err)
+		require.NotNil(t, network)
+	})
+
+	t.Run("multiple proxies", func(t *testing.T) {
+		conf := &config.Config{}
+		for _, endpoint := range []string{"socks5://127.0.0.1:1080", "socks5://127.0.0.1:1081"} {
+			proxy := config.TypeProxyURL{}
+			require.NoError(t, proxy.Set(endpoint))
+			conf.Network.Proxies = append(conf.Network.Proxies, proxy)
+		}
+
+		network, err := makeNetwork(conf, "test")
+		require.NoError(t, err)
+		require.NotNil(t, network)
+	})
+
+	t.Run("invalid proxy", func(t *testing.T) {
+		conf := &config.Config{}
+		conf.Network.Proxies = []config.TypeProxyURL{{
+			Value: &url.URL{Scheme: "http", Host: "127.0.0.1"},
+		}}
+
+		_, err := makeNetwork(conf, "test")
+		require.ErrorContains(t, err, "cannot use")
+	})
+}
+
+func TestMakeAntiReplayCache(t *testing.T) {
+	conf := &config.Config{}
+	require.NotNil(t, makeAntiReplayCache(conf))
+
+	conf.Defense.AntiReplay.Enabled.Value = true
+	require.NoError(t, conf.Defense.AntiReplay.MaxSize.Set("1KB"))
+	require.NoError(t, conf.Defense.AntiReplay.ErrorRate.Set("0.01"))
+	require.NotNil(t, makeAntiReplayCache(conf))
+}
+
+func TestMakeIPLists(t *testing.T) {
+	log := logger.NewNoopLogger()
+	network, err := makeNetwork(&config.Config{}, "test")
+	require.NoError(t, err)
+	callback := ipblocklist.FireholUpdateCallback(func(context.Context, int) {})
+
+	blocklist, err := makeIPBlocklist(config.ListConfig{}, log, network, callback)
+	require.NoError(t, err)
+	require.NotNil(t, blocklist)
+
+	allowlist, err := makeIPAllowlist(config.ListConfig{}, log, network, callback)
+	require.NoError(t, err)
+	require.NotNil(t, allowlist)
+	allowlist.Shutdown()
+}
+
+func TestMakeEventStream(t *testing.T) {
+	log := logger.NewNoopLogger()
+
+	stream, err := makeEventStream(&config.Config{}, log)
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+
+	t.Run("invalid statsd", func(t *testing.T) {
+		conf := &config.Config{}
+		conf.Stats.StatsD.Enabled.Value = true
+		conf.Stats.StatsD.TagFormat.Value = "invalid"
+		_, err := makeEventStream(conf, log)
+		require.ErrorContains(t, err, "statsd")
+	})
+
+	t.Run("invalid prometheus listener", func(t *testing.T) {
+		conf := &config.Config{}
+		conf.Stats.Prometheus.Enabled.Value = true
+		conf.Stats.Prometheus.BindTo.Value = "invalid address"
+		_, err := makeEventStream(conf, log)
+		require.ErrorContains(t, err, "prometheus")
+	})
+}
+
+func TestWarningFastPaths(t *testing.T) {
+	conf := &config.Config{}
+	warnSNIMismatch(conf, nil, logger.NewNoopLogger())
+
+	conf.DomainFrontingIP.Value = []byte{192, 0, 2, 1}
+	conf.DomainFronting.IP.Value = []byte{192, 0, 2, 2}
+	warnDeprecatedDomainFronting(conf, logger.NewNoopLogger())
+}

--- a/internal/cli/run_proxy_internal_test.go
+++ b/internal/cli/run_proxy_internal_test.go
@@ -79,11 +79,12 @@ func TestMakeIPLists(t *testing.T) {
 	blocklist, err := makeIPBlocklist(config.ListConfig{}, log, network, callback)
 	require.NoError(t, err)
 	require.NotNil(t, blocklist)
+	defer blocklist.Shutdown()
 
 	allowlist, err := makeIPAllowlist(config.ListConfig{}, log, network, callback)
 	require.NoError(t, err)
 	require.NotNil(t, allowlist)
-	allowlist.Shutdown()
+	defer allowlist.Shutdown()
 }
 
 func TestMakeEventStream(t *testing.T) {

--- a/internal/cli/simple_run_test.go
+++ b/internal/cli/simple_run_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IceCodeNew/mtg/internal/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecret = "7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"
+
+func validSimpleRun() SimpleRun {
+	return SimpleRun{
+		BindTo:              "127.0.0.1:3128",
+		Secret:              testSecret,
+		Concurrency:         1,
+		PreferIP:            "prefer-ipv6",
+		DomainFrontingPort:  443,
+		DOHIP:               net.ParseIP("192.0.2.1"),
+		Timeout:             time.Second,
+		AntiReplayCacheSize: "1MB",
+	}
+}
+
+func TestSimpleRunValidationErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*SimpleRun)
+		want   string
+	}{
+		{"bind", func(s *SimpleRun) { s.BindTo = "bad" }, "incorrect bind-to"},
+		{"secret", func(s *SimpleRun) { s.Secret = "bad" }, "incorrect secret"},
+		{"concurrency", func(s *SimpleRun) { s.Concurrency = 65536 }, "incorrect concurrency"},
+		{"prefer ip", func(s *SimpleRun) { s.PreferIP = "sometimes" }, "incorrect prefer-ip"},
+		{"fronting port", func(s *SimpleRun) { s.DomainFrontingPort = 65536 }, "incorrect domain-fronting-port"},
+		{"fronting host", func(s *SimpleRun) { s.DomainFrontingHost = "host:443" }, "incorrect domain-fronting-host"},
+		{"deprecated fronting ip", func(s *SimpleRun) { s.DomainFrontingIP = "invalid" }, "incorrect domain-fronting-ip"},
+		{"doh ip", func(s *SimpleRun) { s.DOHIP = nil }, "incorrect doh-ip"},
+		{"timeout", func(s *SimpleRun) { s.Timeout = -time.Second }, "incorrect timeout"},
+		{"antireplay", func(s *SimpleRun) { s.AntiReplayCacheSize = "many" }, "incorrect antireplay-cache-size"},
+		{"proxy", func(s *SimpleRun) { s.Socks5Proxies = []string{"http://proxy"} }, "incorrect socks5 proxy URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command := validSimpleRun()
+			tt.mutate(&command)
+
+			err := command.Run(&CLI{}, "test")
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestGenerateSecret(t *testing.T) {
+	for _, hex := range []bool{false, true} {
+		t.Run(map[bool]string{false: "base64", true: "hex"}[hex], func(t *testing.T) {
+			command := GenerateSecret{HostName: "example.com", Hex: hex}
+			cli := &CLI{GenerateSecret: command}
+
+			output := testlib.CaptureStdout(func() {
+				require.NoError(t, command.Run(cli, "test"))
+			})
+			require.NotEmpty(t, strings.TrimSpace(output))
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,6 +74,45 @@ func (suite *ConfigTestSuite) TestString() {
 	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
 	suite.NoError(err)
 	suite.NotEmpty(conf.String())
+}
+
+func (suite *ConfigTestSuite) TestCompatibilityGetters() {
+	conf := &config.Config{}
+
+	suite.Equal(uint(7), conf.GetConcurrency(7))
+	suite.Equal(uint(443), conf.GetDomainFrontingPort(443))
+	suite.False(conf.GetDomainFrontingProxyProtocol(false))
+	suite.Nil(conf.GetDNS())
+
+	suite.Require().NoError(conf.Concurrency.Set("11"))
+	suite.Require().NoError(conf.DomainFrontingPort.Set("8443"))
+	suite.Require().NoError(conf.DomainFronting.Port.Set("9443"))
+	conf.DomainFrontingProxyProtocol.Value = true
+
+	suite.Equal(uint(11), conf.GetConcurrency(7))
+	suite.Equal(uint(9443), conf.GetDomainFrontingPort(443))
+	suite.True(conf.GetDomainFrontingProxyProtocol(false))
+
+	conf.DomainFronting.Port.Value = 0
+	suite.Equal(uint(8443), conf.GetDomainFrontingPort(443))
+
+	conf.DomainFrontingProxyProtocol.Value = false
+	conf.DomainFronting.ProxyProtocol.Value = true
+	suite.True(conf.GetDomainFrontingProxyProtocol(false))
+
+	conf.Network.DOHIP.Value = net.ParseIP("192.0.2.1")
+	suite.Equal(&url.URL{Scheme: "https", Host: "192.0.2.1"}, conf.GetDNS())
+
+	suite.Require().NoError(conf.Network.DNS.Set("udp://192.0.2.53"))
+	suite.Equal("udp://192.0.2.53", conf.GetDNS().String())
+}
+
+func (suite *ConfigTestSuite) TestValidateErrors() {
+	conf := &config.Config{}
+	suite.ErrorContains(conf.Validate(), "invalid secret")
+
+	suite.Require().NoError(conf.Secret.Set("7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"))
+	suite.ErrorContains(conf.Validate(), "incorrect bind-to")
 }
 
 func (suite *ConfigTestSuite) TestDomainFrontingIPIgnoredWhenHostSet() {

--- a/internal/proxyprotocol/adapter_test.go
+++ b/internal/proxyprotocol/adapter_test.go
@@ -1,0 +1,54 @@
+package proxyprotocol
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/stretchr/testify/require"
+)
+
+type failingListener struct{}
+
+func (failingListener) Accept() (net.Conn, error) { return nil, errors.New("accept failed") }
+func (failingListener) Close() error              { return nil }
+func (failingListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+func TestListenerAdapterAcceptError(t *testing.T) {
+	listener := &ListenerAdapter{Listener: proxyproto.Listener{Listener: failingListener{}}}
+	_, err := listener.Accept()
+	require.ErrorContains(t, err, "accept failed")
+}
+
+func TestListenerAdapterAcceptTCP(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { base.Close() }) //nolint:errcheck
+
+	listener := &ListenerAdapter{Listener: proxyproto.Listener{
+		Listener:          base,
+		ReadHeaderTimeout: -1,
+	}}
+
+	client, err := net.DialTimeout("tcp", base.Addr().String(), time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() }) //nolint:errcheck
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+	require.NoError(t, conn.(interface{ CloseRead() error }).CloseRead())
+	require.NoError(t, conn.(interface{ CloseWrite() error }).CloseWrite())
+	require.NoError(t, conn.Close())
+}
+
+func TestConnWrapperRejectsNonTCPConnections(t *testing.T) {
+	left, right := net.Pipe()
+	t.Cleanup(func() { left.Close() })  //nolint:errcheck
+	t.Cleanup(func() { right.Close() }) //nolint:errcheck
+
+	conn := connWrapper{Conn: proxyproto.NewConn(left)}
+	require.Panics(t, func() { _ = conn.CloseRead() })
+	require.Panics(t, func() { _ = conn.CloseWrite() })
+}

--- a/internal/utils/net_listener_test.go
+++ b/internal/utils/net_listener_test.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type failingListener struct{}
+
+func (failingListener) Accept() (net.Conn, error) { return nil, errors.New("accept failed") }
+func (failingListener) Close() error              { return nil }
+func (failingListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+func TestListenerAcceptError(t *testing.T) {
+	_, err := (Listener{Listener: failingListener{}}).Accept()
+	require.ErrorContains(t, err, "accept failed")
+}
+
+func TestNewListener(t *testing.T) {
+	_, err := NewListener("not-an-address", 0)
+	require.Error(t, err)
+
+	listener, err := NewListener("127.0.0.1:0", 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() }) //nolint:errcheck
+
+	accepted := make(chan net.Conn, 1)
+	errs := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			errs <- acceptErr
+
+			return
+		}
+		accepted <- conn
+	}()
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() }) //nolint:errcheck
+
+	select {
+	case conn := <-accepted:
+		require.NoError(t, conn.Close())
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("listener did not accept connection")
+	}
+}
+
+func TestRootContextHandlesTerminationSignal(t *testing.T) {
+	ctx := RootContext()
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGTERM))
+
+	select {
+	case <-ctx.Done():
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("root context was not canceled")
+	}
+}

--- a/ipblocklist/files/http_test.go
+++ b/ipblocklist/files/http_test.go
@@ -82,6 +82,16 @@ func (suite *HTTPTestSuite) TestOk() {
 	data, err := io.ReadAll(readCloser)
 	suite.NoError(err)
 	suite.Equal("Hooray!", strings.TrimSpace(string(data)))
+	suite.Equal(suite.httpServer.URL+"/readable", file.String())
+}
+
+func (suite *HTTPTestSuite) TestCanceledContext() {
+	file, err := suite.makeFile("readable")
+	suite.NoError(err)
+
+	suite.ctxCancel()
+	_, err = file.Open(suite.ctx)
+	suite.ErrorIs(err, context.Canceled)
 }
 
 func TestHTTP(t *testing.T) {

--- a/ipblocklist/files/local_test.go
+++ b/ipblocklist/files/local_test.go
@@ -47,6 +47,7 @@ func (suite *LocalTestSuite) TestOk() {
 	suite.NoError(err)
 
 	suite.Equal("Hooray!", strings.TrimSpace(string(data)))
+	suite.Equal(suite.getLocalFile("readable"), file.String())
 }
 
 func TestLocal(t *testing.T) {

--- a/ipblocklist/files/mem_test.go
+++ b/ipblocklist/files/mem_test.go
@@ -34,6 +34,17 @@ func (suite *MemTestSuite) TestOk() {
 
 	suite.Contains(strData, "192.168.0.0/24")
 	suite.Contains(strData, "2001:db8:8000::/36")
+	suite.Equal("mem", file.String())
+}
+
+func (suite *MemTestSuite) TestEmpty() {
+	file := files.NewMem(nil)
+	reader, err := file.Open(context.Background())
+	suite.NoError(err)
+
+	data, err := io.ReadAll(reader)
+	suite.NoError(err)
+	suite.Empty(data)
 }
 
 func TestMem(t *testing.T) {

--- a/network/default_test.go
+++ b/network/default_test.go
@@ -54,6 +54,13 @@ func (suite *DefaultDialerTestSuite) TestConnectOk() {
 	conn.Close() //nolint: errcheck
 }
 
+func (suite *DefaultDialerTestSuite) TestConnectWithoutContext() {
+	conn, err := suite.d.Dial("tcp", suite.HTTPServerAddress())
+	suite.NoError(err)
+	suite.NotNil(conn)
+	suite.NoError(conn.Close())
+}
+
 func (suite *DefaultDialerTestSuite) TestHTTPRequest() {
 	httpClient := suite.MakeHTTPClient(suite.d)
 

--- a/network/v2/multi_network_internal_test.go
+++ b/network/v2/multi_network_internal_test.go
@@ -1,0 +1,85 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/IceCodeNew/mtg/essentials"
+	"github.com/stretchr/testify/require"
+)
+
+type stubNetwork struct {
+	dialErr    error
+	dialCalls  int
+	native     *net.Dialer
+	httpClient *http.Client
+}
+
+func (n *stubNetwork) Dial(network, address string) (essentials.Conn, error) {
+	return n.DialContext(context.Background(), network, address)
+}
+
+func (n *stubNetwork) DialContext(context.Context, string, string) (essentials.Conn, error) {
+	n.dialCalls++
+
+	return nil, n.dialErr
+}
+
+func (n *stubNetwork) NativeDialer() *net.Dialer { return n.native }
+
+func (n *stubNetwork) MakeHTTPClient(
+	func(context.Context, string, string) (essentials.Conn, error),
+) *http.Client {
+	return n.httpClient
+}
+
+func TestMultiNetwork(t *testing.T) {
+	_, err := Join()
+	require.Error(t, err)
+
+	firstErr := errors.New("first")
+	secondErr := errors.New("second")
+	first := &stubNetwork{dialErr: firstErr, native: &net.Dialer{}, httpClient: &http.Client{}}
+	second := &stubNetwork{dialErr: secondErr}
+	joined, err := Join(first, second)
+	require.NoError(t, err)
+
+	_, err = joined.Dial("tcp", "example.invalid:443")
+	require.ErrorIs(t, err, ErrCannotDial)
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, secondErr)
+	require.Equal(t, 1, first.dialCalls)
+	require.Equal(t, 1, second.dialCalls)
+	require.Same(t, first.native, joined.NativeDialer())
+	require.Same(t, first.httpClient, joined.MakeHTTPClient(nil))
+}
+
+type stubContextDialer struct {
+	conn net.Conn
+	err  error
+}
+
+func (d stubContextDialer) Dial(string, string) (net.Conn, error) { return d.conn, d.err }
+
+func (d stubContextDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	return d.conn, d.err
+}
+
+func TestProxyNetworkDial(t *testing.T) {
+	base := &stubNetwork{httpClient: &http.Client{}}
+	proxy := proxyNetwork{Network: base, client: stubContextDialer{err: errors.New("proxy offline")}}
+	_, err := proxy.Dial("tcp", "example.invalid:443")
+	require.ErrorContains(t, err, "proxy offline")
+
+	left, right := net.Pipe()
+	t.Cleanup(func() { left.Close() })  //nolint:errcheck
+	t.Cleanup(func() { right.Close() }) //nolint:errcheck
+	proxy.client = stubContextDialer{conn: left}
+	conn, err := proxy.DialContext(context.Background(), "tcp", "example.invalid:443")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Same(t, base.httpClient, proxy.MakeHTTPClient(nil))
+}


### PR DESCRIPTION
## What changed

- add coverage for build metadata and connection adapters
- exercise CLI access output, validation, doctor diagnostics, and component construction
- cover config compatibility getters, file abstractions, listeners, proxy protocol wrapping, and composed networks
- test both success and failure paths with local or in-memory dependencies

## Coverage

Total statement coverage increases from **69.1%** to **80.3%** (+11.2 percentage points).

Reaching 100% is not practical without reducing test quality or restructuring production code. The largest remaining areas are:

- the full proxy lifecycle and `os.Exit` paths, which require subprocess/integration orchestration
- real NTP, Telegram handshake, DNS, and public-IP failure modes, which would make unit tests externally dependent and flaky
- kernel- and OS-specific socket error branches that cannot be injected portably
- test-only mocks/helpers, where testing the test doubles would not validate production behavior
- deeply concurrent relay/doppelganger failure paths that need dedicated fault-injection seams

These areas are better addressed by focused integration tests or production dependency-injection changes in separate PRs.

## Validation

- `mise tasks run lint` — 0 issues
- `mise tasks run covtest` — passes with race detection, two runs, and real-network tests unchanged
- total coverage: 80.3%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for CLI commands, configuration validation, networking, proxy handling, connection lifecycle, signal cancellation, IP blocklists, and version reporting.
  * Added checks for successful and failing network operations, address-family filtering, proxy configurations, warning paths, and invalid inputs.
  * Improved verification of generated URLs, secrets, file representations, and context cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->