### PR TITLE
Upgrade Go toolchain to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # BUILD STAGE
 
-FROM golang:1.26-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 ENV CGO_ENABLED=0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IceCodeNew/mtg
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8


### PR DESCRIPTION
## What changed

- require Go 1.26.5 in `go.mod`
- pin the Docker build stage to `golang:1.26.5-alpine`

## Why

Go 1.26.4 is affected by `GO-2026-5856`, an Encrypted Client Hello privacy leak in `crypto/tls`. The vulnerability is fixed in Go 1.26.5 and is reachable through this project's TLS call graph.

## Validation

- `govulncheck ./...` reports 0 reachable vulnerabilities
- `mise tasks run lint` reports 0 issues
- `mise tasks run test` passes with race detection, including the unconditional real-network tests
- verified that the official multi-platform `golang:1.26.5-alpine` image exists
